### PR TITLE
feat: POL-3577 - Update GTM integration to Consent Mode V2

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -220,7 +220,7 @@ const main = (data) => {
 
   setDefaultConsentState(defaultData);
 
-  // Set Implicit Defaults everywhere else
+  // Set implicit defaults everywhere else
   setDefaultConsentState({
     ad_storage: 'granted',
     analytics_storage: 'granted',

--- a/template.tpl
+++ b/template.tpl
@@ -122,6 +122,42 @@ const getCookieValues = require("getCookieValues");
 const callInWindow = require("callInWindow");
 const gtagSet = require("gtagSet");
 
+const EEA_UK_COUNTRY_CODES = [
+  "AT",
+  "BE",
+  "BG",
+  "CY",
+  "CZ",
+  "DE",
+  "DK",
+  "EE",
+  "ES",
+  "FI",
+  "FR",
+  "GB",
+  "GR",
+  "HR",
+  "HU",
+  "IE",
+  "IS",
+  "IT",
+  "LI",
+  "LT",
+  "LU",
+  "LV",
+  "MT",
+  "NL",
+  "NO",
+  "PL",
+  "PT",
+  "RO",
+  "SE",
+  "SI",
+  "SK",
+  "UK",
+];
+
+
 // Transform an object of booleans into an object
 // of granted/denied strings for sending to GTM
 const parseConsent = (consent) => {
@@ -131,6 +167,8 @@ const parseConsent = (consent) => {
     functionality_storage: consent.functionalityConsentGranted ? "granted" : "denied",
     personalization_storage: consent.personalizationConsentGranted ? "granted" : "denied",
     security_storage: consent.securityConsentGranted ? "granted" : "denied",
+    ad_user_data: consent.adConsentGranted ? "granted" : "denied",
+    ad_personalization: consent.adConsentGranted ? "granted" : "denied",
   };
 };
 
@@ -175,10 +213,24 @@ const main = (data) => {
   // Set developer ID
   // gtagSet('developer_id.<replace_with_your_developer_id>', true);
 
-  // Set default consent state(s)
+  // Set default consent required state(s)
   let defaultData = parseConsentDefaults(data);
   defaultData.wait_for_update = 500;
+  defaultData.region = EEA_UK_COUNTRY_CODES;
+
   setDefaultConsentState(defaultData);
+
+  // Set Implicit Defaults everywhere else
+  setDefaultConsentState({
+    ad_storage: 'granted',
+    analytics_storage: 'granted',
+    functionality_storage: 'granted',
+    personalization_storage: 'granted',
+    security_storage: 'granted',
+    ad_user_data: 'granted',
+    ad_personalization: 'granted',
+    wait_for_update: 500,
+  });
 
   // Set data redaction value
   gtagSet('adsDataRedaction', data.adsDataRedaction);
@@ -513,6 +565,68 @@ ___WEB_PERMISSIONS___
                   {
                     "type": 1,
                     "string": "wait_for_update"
+                  },
+                  {
+                    "type": 8,
+                    "boolean": false
+                  },
+                  {
+                    "type": 8,
+                    "boolean": true
+                  }
+                ]
+              },
+              {
+                "type": 3,
+                "mapKey": [
+                  {
+                    "type": 1,
+                    "string": "consentType"
+                  },
+                  {
+                    "type": 1,
+                    "string": "read"
+                  },
+                  {
+                    "type": 1,
+                    "string": "write"
+                  }
+                ],
+                "mapValue": [
+                  {
+                    "type": 1,
+                    "string": "ad_user_data"
+                  },
+                  {
+                    "type": 8,
+                    "boolean": false
+                  },
+                  {
+                    "type": 8,
+                    "boolean": true
+                  }
+                ]
+              },
+              {
+                "type": 3,
+                "mapKey": [
+                  {
+                    "type": 1,
+                    "string": "consentType"
+                  },
+                  {
+                    "type": 1,
+                    "string": "read"
+                  },
+                  {
+                    "type": 1,
+                    "string": "write"
+                  }
+                ],
+                "mapValue": [
+                  {
+                    "type": 1,
+                    "string": "ad_personalization"
                   },
                   {
                     "type": 8,

--- a/template.tpl
+++ b/template.tpl
@@ -65,7 +65,7 @@ ___TEMPLATE_PARAMETERS___
             "type": "NON_EMPTY"
           }
         ]
-      },      
+      },
       {
         "type": "CHECKBOX",
         "name": "personalizationStorage",
@@ -413,7 +413,7 @@ ___WEB_PERMISSIONS___
                   },
                   {
                     "type": 8,
-                    "boolean": false
+                    "boolean": true
                   },
                   {
                     "type": 8,
@@ -444,7 +444,7 @@ ___WEB_PERMISSIONS___
                   },
                   {
                     "type": 8,
-                    "boolean": false
+                    "boolean": true
                   },
                   {
                     "type": 8,
@@ -475,7 +475,7 @@ ___WEB_PERMISSIONS___
                   },
                   {
                     "type": 8,
-                    "boolean": false
+                    "boolean": true
                   },
                   {
                     "type": 8,
@@ -506,7 +506,7 @@ ___WEB_PERMISSIONS___
                   },
                   {
                     "type": 8,
-                    "boolean": false
+                    "boolean": true
                   },
                   {
                     "type": 8,
@@ -537,7 +537,7 @@ ___WEB_PERMISSIONS___
                   },
                   {
                     "type": 8,
-                    "boolean": false
+                    "boolean": true
                   },
                   {
                     "type": 8,
@@ -599,7 +599,7 @@ ___WEB_PERMISSIONS___
                   },
                   {
                     "type": 8,
-                    "boolean": false
+                    "boolean": true
                   },
                   {
                     "type": 8,
@@ -630,7 +630,7 @@ ___WEB_PERMISSIONS___
                   },
                   {
                     "type": 8,
-                    "boolean": false
+                    "boolean": true
                   },
                   {
                     "type": 8,
@@ -653,7 +653,16 @@ ___WEB_PERMISSIONS___
 
 ___TESTS___
 
-scenarios: []
+scenarios:
+- name: Implicit consent by default (since we can't mock region)
+  code: "const isConsentGranted = require('isConsentGranted');\n\nconst mockData =\
+    \ {\n  // Mocked field values\n  analyticsStorage: true,\n  adStorage: true,\n\
+    \  personalizationStorage: true,\n  functionalityStorage: true,\n};  \n\n// Call\
+    \ runCode to run the template's code.\nrunCode(mockData);\n\nassertThat(isConsentGranted('ad_storage')).isEqualTo(true);\n\
+    assertThat(isConsentGranted('ad_user_data')).isEqualTo(true);\nassertThat(isConsentGranted('ad_personalization')).isEqualTo(true);\n\
+    assertThat(isConsentGranted('personalization_storage')).isEqualTo(true);\nassertThat(isConsentGranted('analytics_storage')).isEqualTo(true);\n\
+    assertThat(isConsentGranted('functionality_storage')).isEqualTo(true);\nassertThat(isConsentGranted('security_storage')).isEqualTo(true);\n\
+    \n// Verify that the tag finished successfully.\nassertApi('gtmOnSuccess').wasCalled();"
 
 
 ___NOTES___


### PR DESCRIPTION
This PR updates the exported TrueVault GTM template with the changes from [POL-3577](https://linear.app/truevault/issue/POL-3577/update-gtm-integration-to-consent-mode-v2):

* Adds `ad_user_data` and `ad_personalization` fields
* Adds a basic [GTM test](https://developers.google.com/tag-platform/tag-manager/templates/tests) to test implicit consent

More details in `polaris-cmp` [PR 41](https://github.com/truevault/polaris-cmp/pull/41).