### PR TITLE
feat: POL-3202 - Release update for Consent Mode V2

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -2,9 +2,11 @@ homepage: "https://www.truevault.com"
 documentation: "https://help.truevault.com/article/165-setting-up-consent-management-in-google-tag-manager#which-category"
 versions:
   # Latest version
+  - sha: 04840753007745446ecf0f083276e24feefbf4ed
+    changeNotes: Update to support Consent Mode V2
+  # Older versions
   - sha: dee26f1fdf4f86f3fe7751e225f3b4c6aeb4f9ca
     changeNotes: Minor code update
-  # Older versions
   - sha: fc6ae0456a86a090a47012dd35cd4cf23e982b78
     changeNotes: Update display name  
   - sha: 607f85a1b51d47fffdcc7726f8c319a392b52c5f


### PR DESCRIPTION
This PR [updates](https://developers.google.com/tag-platform/tag-manager/templates/gallery#update_your_template) `metadata.yaml` to publish a new version of our GTM template that supports Consent Mode V2.

After the GTM Gallery has picked up the change (within 2-3 days), organizations will need to update to the latest version of the template within GTM.